### PR TITLE
Ready for engineers to add reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # forge
-docs/
 out/
 cache/
 # node

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,36 @@
+---
+title: Introduction to Phylax Node
+description: 'Welcome to a new easier way to monitor your dapp'
+---
+
+<img
+  className="block dark:hidden"
+  src="/images/hero-light.svg"
+  alt="Hero Light"
+/>
+<img
+  className="hidden dark:block"
+  src="/images/hero-dark.svg"
+  alt="Hero Dark"
+/>
+
+## Setting up
+
+As part of "docs-driven development", we're going to document code
+as we commit it and enforce that in the PR approvals flow.
+
+It's easy to add to the docs! Either add markdown/MDX syntax to an
+existing file in /docs, or add a new one (feel free to copy from an
+existing one of the same style). 
+
+To add a new file:
+ - Create ./docs/mynewfile.mdx or ./docs/sdk-reference/myfeature.mdx etc
+ - If you want it to show in the sidebar menu, add it to Navigation in ./mint.js
+
+## Testing
+
+We don't have a staging site set up for docs yet, so it'll be a bit manual
+ - Commit and push the new docs to this repo
+ - Go to the [github action](https://github.com/phylaxsystems/phylax-docs/actions/workflows/mintlify-compile-docs.yml) for the docs repo
+ - At the top of the table showing past workflow runs, on the right side, hit the "Run Workflow" button and run on the main branch
+ - cd to the docs repo, checkout the latest from the `docs-prod` branch, and run `mintlify dev` to see the resulting website

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Phylax Node
+title: Introduction to Phylax STL
 description: 'Welcome to a new easier way to monitor your dapp'
 ---
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Phylax STL
+title: Intro to the Phylax Standard Library
 description: 'Welcome to a new easier way to monitor your dapp'
 ---
 

--- a/docs/sdk-reference/sample-feature.mdx
+++ b/docs/sdk-reference/sample-feature.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Sample Feature'
+description: 'Clone yours from this one if you like'
+icon: 'square-caret-down'
+---
+
+## Example reference page from the [Mintlify Docs](https://mintlify.com/docs/content/components/accordions) ([code here](https://github.com/mintlify/docs/blob/main/content/components/accordions.mdx))
+
+<Accordion title="I am an Accordion.">
+  You can put any content in here. Check out
+  [AccordionGroup](/content/components/accordion-group) if you want to group
+  multiple Accordions into a single display.
+</Accordion>
+
+<RequestExample>
+  ```jsx Accordion Example
+  <Accordion title="I am an Accordion.">
+    You can put any content in here.
+  </Accordion>
+  ```
+</RequestExample>
+
+## Props
+
+<ResponseField name="title" type="string" required>
+  Title in the Accordion preview.
+</ResponseField>
+
+<ResponseField name="description" type="string">
+  Detail below the title in the Accordion preview.
+</ResponseField>
+
+<ResponseField name="defaultOpen" type="boolean" default="false">
+  Whether the Accordion is open by default.
+</ResponseField>
+
+<ResponseField name="icon" type="string or svg">
+  A [Font Awesome icon](https://fontawesome.com/icons) or SVG code
+</ResponseField>
+
+<ResponseField name="iconType" type="string">
+  One of "regular", "solid", "light", "thin", "sharp-solid", "duotone", or
+  "brands"
+</ResponseField>

--- a/mint.json
+++ b/mint.json
@@ -1,0 +1,12 @@
+{
+  "navigation": [
+    {
+      "group": "Phylax Standard Library",
+      "pages": [
+        "introduction",
+        "quickstart",
+        "reference"
+      ]
+    }
+  ]
+}

--- a/mint.json
+++ b/mint.json
@@ -7,7 +7,7 @@
         {
           "group": "SDK Reference",
           "pages": [
-            "docs/sdk-reference/sample-feature.mdx"
+            "docs/sdk-reference/sample-feature"
           ]
         }
       ]

--- a/mint.json
+++ b/mint.json
@@ -7,7 +7,7 @@
         {
           "group": "SDK Reference",
           "pages": [
-            "sdk-reference/sample-feature.mdx"
+            "docs/sdk-reference/sample-feature.mdx"
           ]
         }
       ]

--- a/mint.json
+++ b/mint.json
@@ -3,9 +3,13 @@
     {
       "group": "Phylax Standard Library",
       "pages": [
-        "introduction",
-        "quickstart",
-        "reference"
+        "docs/introduction",
+        {
+          "group": "SDK Reference",
+          "pages": [
+            "sdk-reference/sample-feature.mdx"
+          ]
+        }
       ]
     }
   ]


### PR DESCRIPTION
<img width="1441" alt="image" src="https://github.com/phylaxsystems/phylax-std/assets/151620/41aea058-52b0-40f5-abcd-944a377ae469">


Now whenever the docs github action runs, it'll pull down docs from this repo and into the sidebar section on the lower left of this screenshot (the "Phylax Standard Library" label and everything under it is defined in this repo and dropped in to the site) 

There's a group for reference docs, with a sample page people can copy if they like. There's also an introduction page with some pointers, as an example of top-level pages you can add