### PR TITLE
feat: Add solidity behavior for instantiating charts easily from Alerts 

### DIFF
--- a/src/Action.sol
+++ b/src/Action.sol
@@ -5,6 +5,6 @@ pragma experimental ABIEncoderV2;
 import {Script} from "forge-std/Script.sol";
 import {PhylaxBase} from "./PhylaxBase.sol";
 
-/// @title Alert
-/// @dev Base contract for all Phylax alert contracts.
+/// @title Action
+/// @dev Base contract for all Phylax action contracts.
 abstract contract Action is PhylaxBase, Script {}

--- a/src/Alert.sol
+++ b/src/Alert.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.2 <0.9.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import {Test} from "forge-std/Test.sol";
 import {PhylaxBase} from "./PhylaxBase.sol";
 import {PhylaxNotification} from "./PhylaxNotification.sol";
+import {PhylaxCharts} from "./PhylaxCharts.sol";
 
 /// @title Alert
 /// @dev Base contract for all Phylax alert contracts.
-abstract contract Alert is PhylaxBase, PhylaxNotification, Test {}
+abstract contract Alert is PhylaxBase, PhylaxCharts, PhylaxNotification, Test {}

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -84,7 +84,7 @@ abstract contract PhylaxBase is CommonBase {
         uint8 visualization,
         uint8 dataPointType,
         Label[] memory labels
-    ) external requirePhoundry {
+    ) external {
         emit PhylaxCreateMonitor(
             chartName,
             description,
@@ -94,5 +94,4 @@ abstract contract PhylaxBase is CommonBase {
             labels
         );
     }
-.
 }

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -16,6 +16,12 @@ abstract contract PhylaxBase is CommonBase {
     /// @dev Event to export key value pair
     event PhylaxExport(string key, string value);
 
+    /// @dev Struct for labels
+    struct Label {
+        string key;
+        string value;
+    }
+
     /// @notice Modifier to select a chain
     /// @dev Exports "fork_activated" and selects the fork at the given index
     /// @param index The index of the chain to select
@@ -52,5 +58,41 @@ abstract contract PhylaxBase is CommonBase {
         emit PhylaxExport(key, value);
     }
 
-    /// Add additional events here ...
+    /// @dev Event for creating a monitor
+    event PhylaxCreateMonitor(
+        string name,
+        string description,
+        string unitLabel,
+        uint8 visualization,
+        uint8 dataPointType,
+        Label[] labels
+    );
+
+    /// @notice Setup a unique monitor for your Alert in Phylax
+    /// @dev This is only scanned during the `setUp` function of 
+    /// the alert, it's output will not be read when tests are running.
+    /// @param chartName The name of the chart
+    /// @param description The description of the chart
+    /// @param unitLabel The unit label of the chart
+    /// @param visualization The visualization of the chart
+    /// @param dataPointType The data point type of the chart
+    /// @param labels The labels of the chart
+    function createChartMonitor(
+        string memory chartName,
+        string memory description,
+        string memory unitLabel,
+        uint8 visualization,
+        uint8 dataPointType,
+        Label[] memory labels
+    ) external requirePhoundry {
+        emit PhylaxCreateMonitor(
+            chartName,
+            description,
+            unitLabel,
+            visualization,
+            dataPointType,
+            labels
+        );
+    }
+.
 }

--- a/src/PhylaxCharts.sol
+++ b/src/PhylaxCharts.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+import {PhylaxBase} from "./PhylaxBase.sol";
+import {console} from "forge-std/console.sol";
+import {Phylax} from "./Phylax.sol";
+
+/// @title PhylaxCharts
+/// @dev Base contract for all Phylax charts contracts.
+abstract contract PhylaxCharts is PhylaxBase {
+    Chart[] public phylaxCharts;
+    mapping(string => ChartMapping) public chartDataTypeByName;
+
+    struct Chart {
+        string chartName;
+        string description;
+        string unitLabel;
+        Visualisation visualization;
+        DataPointType dataPointType;
+        Label[] labels;
+    }
+
+    struct ChartMapping {
+        string chartName;
+        DataPointType dataPointType;
+    }
+
+    enum Visualisation {
+        Bar,
+        Line,
+        Heatmap,
+        Gauge,
+        Table,
+        LastValue
+    }
+
+    enum DataPointType {
+        Uint,
+        Int,
+        String
+    }
+
+    modifier uniqueChartName(string memory chartName) {
+        require(bytes(chartDataTypeByName[chartName]).length == 0, "Chart already exists");
+        _;
+    }
+
+    // function charts() public virtual;
+    modifier setupCharts() {
+        _;
+        initCharts();
+    }
+
+
+    function initCharts() public virtual returns (PhylaxCharts.Chart[] memory memCharts) {
+        memCharts = new PhylaxCharts.Chart[](phylaxCharts.length);
+        
+        for (uint256 i; i < phylaxCharts.length; i++) {
+            memCharts[i] = phylaxCharts[i];
+            ph.createChartMonitor(
+                phylaxCharts[i].chartName,
+                phylaxCharts[i].description,
+                phylaxCharts[i].unitLabel,
+                uint8(phylaxCharts[i].visualization),
+                uint8(phylaxCharts[i].dataPointType),
+                phylaxCharts[i].labels
+            );
+        }
+    }
+
+    function createChart(
+        string memory chartName,
+        string memory description,
+        string memory unitLabel,
+        Visualisation visualization,
+        DataPointType dataPointType,
+        Label[] memory labels
+    ) public uniqueChartName(chartName) {
+        Chart memory newChart = PhylaxCharts.Chart({
+            chartName: chartName,
+            description: description,
+            unitLabel: unitLabel,
+            visualization: visualization,
+            dataPointType: dataPointType,
+            labels: labels
+        });
+        ChartMapping memory chartMap = ChartMapping({
+            chartName: chartName,
+            dataPointType: dataPointType
+        });
+        chartDataTypeByName[chartName] = chartMap;
+        phylaxCharts.push(newChart);
+    }
+
+    function createChart(
+        string memory chartName,
+        string memory description,
+        string memory unitLabel,
+        Visualisation visualization,
+        DataPointType dataPointType
+    ) public uniqueChartName(chartName) {
+        createChart(chartName, description, unitLabel, visualization, dataPointType, new Label[](0));
+    }
+
+    function createMultiChart(
+        string memory overlayKey,
+        string memory description,
+        string memory unitLabel,
+        Visualisation visualization,
+        DataPointType dataPointType,
+        Label[] memory labels,
+        string[] memory chartNames
+    ) public {
+        Label[] memory extendedLabels = new Label[](labels.length + 1);
+        for (uint256 i = 0; i < labels.length; i++) {
+            extendedLabels[i] = labels[i]
+        }
+
+        extendedLabels[labels.length] = Label { key: overlayKey, value: "overlayChartKey" }; 
+        
+        for (uint256 i = 0; i < chartNames.length; i++) {
+            createChart(
+                chartNames[i],
+                description,
+                unitLabel,
+                visualization,
+                dataPointType,
+                labels
+            );
+        }
+    }
+
+}

--- a/src/PhylaxNotification.sol
+++ b/src/PhylaxNotification.sol
@@ -13,11 +13,6 @@ abstract contract PhylaxNotification is PhylaxBase {
         Critical
     }
 
-    struct Label {
-        string key;
-        string value;
-    }
-
     struct NotificationMessage {
         string summary;
         string description;

--- a/src/PhylaxNotification.sol
+++ b/src/PhylaxNotification.sol
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.2 <0.9.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
+
+import {PhylaxBase} from "./PhylaxBase.sol";
 
 /// @title PhylaxNotification
 /// @dev Base contract for all Phylax notification contracts.
-abstract contract PhylaxNotification {
+abstract contract PhylaxNotification is PhylaxBase {
     enum NotificationSeverity {
         Info,
         Warning,
         Critical
     }
 
-    struct NotificationLabel {
+    struct Label {
         string key;
         string value;
     }
@@ -20,12 +22,12 @@ abstract contract PhylaxNotification {
         string summary;
         string description;
         NotificationSeverity severity;
-        NotificationLabel[] labels;
+        Label[] labels;
     }
 
     // helper functions
     function info(string memory summary, string memory description) public pure returns (NotificationMessage memory) {
-        NotificationLabel[] memory labels;
+        Label[] memory labels;
         return NotificationMessage({
             summary: summary,
             description: description,
@@ -34,7 +36,7 @@ abstract contract PhylaxNotification {
         });
     }
 
-    function info(string memory summary, string memory description, NotificationLabel[] memory labels)
+    function info(string memory summary, string memory description, Label[] memory labels)
         public
         pure
         returns (NotificationMessage memory)
@@ -52,7 +54,7 @@ abstract contract PhylaxNotification {
         pure
         returns (NotificationMessage memory)
     {
-        NotificationLabel[] memory labels;
+        Label[] memory labels;
         return NotificationMessage({
             summary: summary,
             description: description,
@@ -61,7 +63,7 @@ abstract contract PhylaxNotification {
         });
     }
 
-    function warning(string memory summary, string memory description, NotificationLabel[] memory labels)
+    function warning(string memory summary, string memory description, Label[] memory labels)
         public
         pure
         returns (NotificationMessage memory)
@@ -79,7 +81,7 @@ abstract contract PhylaxNotification {
         pure
         returns (NotificationMessage memory)
     {
-        NotificationLabel[] memory labels;
+        Label[] memory labels;
         return NotificationMessage({
             summary: summary,
             description: description,
@@ -88,7 +90,7 @@ abstract contract PhylaxNotification {
         });
     }
 
-    function critical(string memory summary, string memory description, NotificationLabel[] memory labels)
+    function critical(string memory summary, string memory description, Label[] memory labels)
         public
         pure
         returns (NotificationMessage memory)


### PR DESCRIPTION
This change adds interfaces to allow users to create charts from inside of their alert. Monitors could be setup during runtime through these interfaces, but other parts of the system will consume their requests.