### PR TITLE
feat: Send datapoints to monitors via event logs in solidity

### DIFF
--- a/src/Phylax.sol
+++ b/src/Phylax.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import {console} from "forge-std/console.sol";
 import {CommonBase, Vm} from "forge-std/Base.sol";
 
 /// @title Vm-like interface for Phylax

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -10,6 +10,7 @@ import {Phylax} from "./Phylax.sol";
 abstract contract PhylaxBase is CommonBase {
     /// @dev Instance of Phylax contract
     Phylax internal ph = Phylax(address(VM_ADDRESS));
+    
     /// @dev Array of active chains
     uint256[] internal activeChains;
 
@@ -40,7 +41,6 @@ abstract contract PhylaxBase is CommonBase {
     }
 
     /// @notice Enables a new chain
-
     /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
     /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
     /// @param blockNumber The block number at which the chain should be forked
@@ -84,7 +84,7 @@ abstract contract PhylaxBase is CommonBase {
         uint8 visualization,
         uint8 dataPointType,
         Label[] memory labels
-    ) external {
+    ) public {
         emit PhylaxCreateMonitor(
             chartName,
             description,
@@ -93,5 +93,42 @@ abstract contract PhylaxBase is CommonBase {
             dataPointType,
             labels
         );
+    }
+
+    /// @dev Event for exporting monitor string data points
+    event PhylaxWriteStringMonitor(string name, string value, Label[] labels);
+
+    /// @dev Event for exporting monitor uint data points
+    event PhylaxWriteUintMonitor(string name, uint64 value, Label[] labels);
+
+    /// @dev Event for exporting monitor int data points
+    event PhylaxWriteIntMonitor(string name, int64 value, Label[] labels);
+
+
+    /// @notice Send data to a Phylax monitor which accepts string data, if it was instantiated.
+    function writeDataPointString(
+        string memory chartName,
+        string memory value,
+        Label[] memory labels
+    ) public {
+        emit PhylaxWriteStringMonitor(chartName, value, labels);
+    }
+    
+    /// @notice Send data to a Phylax monitor which accepts uint data, if it was instantiated.
+    function writeDataPointUint(
+        string memory chartName,
+        uint64 value,
+        Label[] memory labels
+    ) public {
+        emit PhylaxWriteUintMonitor(chartName, value, labels);
+    }
+
+    /// @notice Send data to a Phylax monitor which accepts int data, if it was instantiated.
+    function writeDataPointInt(
+        string memory chartName,
+        int64 value,
+        Label[] memory labels
+    ) public {
+        emit PhylaxWriteIntMonitor(chartName, value, labels);
     }
 }

--- a/src/PhylaxCharts.sol
+++ b/src/PhylaxCharts.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 import {PhylaxBase} from "./PhylaxBase.sol";
-import {console} from "forge-std/console.sol";
 import {Phylax} from "./Phylax.sol";
 
 /// @title PhylaxCharts
@@ -14,6 +13,9 @@ abstract contract PhylaxCharts is PhylaxBase {
     // and correct incoming data points
     mapping(string => StorageChart) public chartByName;
 
+    /// @notice The chart configuration struct
+    /// @dev Can be exported to create a monitor or chart for the alert, 
+    /// which can then be populated with data points
     struct Chart {
         string chartName;
         string description;
@@ -46,24 +48,29 @@ abstract contract PhylaxCharts is PhylaxBase {
         LastValue
     }
 
+    /// @notice The data point type enum for describing the type of data point you will create.
     enum DataPointType {
         Uint,
         Int,
         String
     }
 
+    /// @notice Modifier to enforce if a chart name is unique.
     modifier uniqueChartName(string memory chartName) {
         require(bytes(chartByName[chartName].chartName).length == 0, "Chart already exists");
         _;
     }
 
-    // function charts() public virtual;
+    /// @notice Modifier to setup charts automatically at the end of a function.
+    /// @dev This modifier is particularly useful when used in the setUp() function of an alert test.
+    /// Charts cannot be made anywhere else but there, so setting them up in that spot is very convenient.
     modifier setupCharts() {
         _;
         initCharts();
     }
 
-
+    /// @dev The function for establishing charts manually, in case there was a need you needed your
+    // charts returned to you.
     function initCharts() public virtual returns (PhylaxCharts.Chart[] memory memCharts) {
         memCharts = new PhylaxCharts.Chart[](PhylaxCharts.phylaxCharts.length);
         
@@ -96,6 +103,14 @@ abstract contract PhylaxCharts is PhylaxBase {
         }
     }
 
+    /// @notice This function will setup a chart with the given parameters 
+    /// and sets it up in the Phylax GUI if executed in the setUp() function.
+    /// @param chartName The name of the chart
+    /// @param description The description of the chart
+    /// @param unitLabel The unit label of the chart
+    /// @param visualization The visualization of the chart
+    /// @param dataPointType The data point type of the chart
+    /// @param labels The labels of the chart
     function createChart(
         string memory chartName,
         string memory description,
@@ -126,6 +141,13 @@ abstract contract PhylaxCharts is PhylaxBase {
         phylaxCharts.push(newChart);
     }
 
+    /// @notice This function will setup a chart with the given parameters 
+    /// and sets it up in the Phylax GUI if executed in the setUp() function.
+    /// @param chartName The name of the chart
+    /// @param description The description of the chart
+    /// @param unitLabel The unit label of the chart
+    /// @param visualization The visualization of the chart
+    /// @param dataPointType The data point type of the chart
     function createChart(
         string memory chartName,
         string memory description,
@@ -136,6 +158,14 @@ abstract contract PhylaxCharts is PhylaxBase {
         createChart(chartName, description, unitLabel, visualization, dataPointType, new Label[](0));
     }
 
+    /// @notice This function create multiple charts that will be overlayed on top of each other by default.
+    /// @param overlayKey The key that will be used to uniquely identify
+    /// a set of charts that should be overlayed on top of each other.
+    /// @param description The description of the chart
+    /// @param unitLabel The unit label of the charts, 
+    /// @param visualization The visualization of the charts
+    /// @param dataPointType The data point type of the charts
+    /// @param labels The labels of the charts
     function createMultiChart(
         string memory overlayKey,
         string memory description,
@@ -164,4 +194,33 @@ abstract contract PhylaxCharts is PhylaxBase {
         }
     }
 
+    function writeToChart(string memory chartName, uint64 value, Label[] memory labels) public {
+        require(chartByName[chartName].dataPointType == DataPointType.Uint, "Invalid dataPointType");
+        writeDataPointUint(chartName, value, labels);
+    }
+
+    function writeToChart(string memory chartName, int64 value, Label[] memory labels) public {
+        require(chartByName[chartName].dataPointType == DataPointType.Int, "Invalid dataPointType");
+        writeDataPointInt(chartName, value, labels);
+    }
+
+    function writeToChart(string memory chartName, address value, Label[] memory labels) public {
+        require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
+        writeDataPointString(chartName, vm.toString(value), labels);
+    }       
+
+    function writeToChart(string memory chartName, string memory value, Label[] memory labels) public {
+        require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
+        writeDataPointString(chartName, value, labels);
+    }
+
+    function writeToChart(string memory chartName, bytes32 value, Label[] memory labels) public {
+        require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
+        writeDataPointString(chartName, vm.toString(value), labels);
+    }
+
+    function writeToChart(string memory chartName, bytes memory value, Label[] memory labels) public {
+        require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
+        writeDataPointString(chartName, vm.toString(value), labels);
+    }
 }


### PR DESCRIPTION
This change simply makes it possible to send datapoints to the monitoring node via event logs, and this functionality will be realized once Phoundry and this repo have their changes merged in.