### PR TITLE
feat: Add CreateFork w chain ID interfaces 

### DIFF
--- a/src/Phylax.sol
+++ b/src/Phylax.sol
@@ -21,6 +21,23 @@ interface Phylax is Vm {
     // the current block number, which enables improved caching and faster execution times
 	function rollForkBack(uint256 forkId, uint256 blocksInThePast) external;
     
+
+    /// Creates a new fork with the given chainId and the _latest_ block, if there is a watcher
+    /// connected to the alert running the cheatcode.
+    function createFork(uint256 chainId) external returns (uint256 forkId);
+
+    /// Creates a new fork with the given chainId and the specified block number, if there is a watcher
+    /// connected to the alert running the cheatcode.
+    function createFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);
+
+    /// Creates and also selects a new fork with the given chainId and the latest block and returns the identifier of the fork.
+    /// If there is no watcher connected to the alert running the cheatcode with the specified chainid, it will fail.
+    function createSelectFork(uint256 chainId) external returns (uint256 forkId);
+    
+    /// Creates and also selects a new fork with the given chainId and block and returns the identifier of the fork.
+    /// If there is no watcher connected to the alert running the cheatcode with the specified chainid, it will fail.
+    function createSelectFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);
+
     /// Add additional cheatcodes here...
 
 }

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -23,6 +23,24 @@ abstract contract PhylaxBase is CommonBase {
         string value;
     }
 
+     /// @notice The visualization enum for describing the type of chart you will create.
+    /// @dev This enum is used to create charts in the Phylax GUI and in the telemetry exports.
+    enum Visualisation {
+        Bar,
+        Line,
+        Heatmap,
+        Gauge,
+        Table,
+        LastValue
+    }
+
+    /// @notice The data point type enum for describing the type of data point you will create.
+    enum DataPointType {
+        Uint,
+        Int,
+        String
+    }
+
     /// @notice Modifier to select a chain
     /// @dev Exports "fork_activated" and selects the fork at the given index
     /// @param index The index of the chain to select
@@ -63,8 +81,8 @@ abstract contract PhylaxBase is CommonBase {
         string name,
         string description,
         string unitLabel,
-        uint8 visualization,
-        uint8 dataPointType,
+        Visualisation visualization,
+        DataPointType dataPointType,
         Label[] labels
     );
 
@@ -74,15 +92,12 @@ abstract contract PhylaxBase is CommonBase {
     /// @param chartName The name of the chart
     /// @param description The description of the chart
     /// @param unitLabel The unit label of the chart
-    /// @param visualization The visualization of the chart
-    /// @param dataPointType The data point type of the chart
-    /// @param labels The labels of the chart
     function createChartMonitor(
         string memory chartName,
         string memory description,
         string memory unitLabel,
-        uint8 visualization,
-        uint8 dataPointType,
+        Visualisation visualization,
+        DataPointType dataPointType,
         Label[] memory labels
     ) public {
         emit PhylaxCreateMonitor(

--- a/src/PhylaxCharts.sol
+++ b/src/PhylaxCharts.sol
@@ -8,10 +8,10 @@ import {Phylax} from "./Phylax.sol";
 /// @dev Base contract for all Phylax charts contracts.
 abstract contract PhylaxCharts is PhylaxBase {
     /// @dev Array of active charts
-    StorageChart[] public phylaxCharts;
+    StorageChart[] internal phylaxCharts;
     /// @dev Mapping of chart name by chart data type to check name uniquness 
     // and correct incoming data points
-    mapping(string => StorageChart) public chartByName;
+    mapping(string => StorageChart) internal chartByName;
 
     /// @notice The chart configuration struct
     /// @dev Can be exported to create a monitor or chart for the alert, 
@@ -53,7 +53,7 @@ abstract contract PhylaxCharts is PhylaxBase {
 
     /// @dev The function for establishing charts manually, in case there was a need you needed your
     // charts returned to you.
-    function initCharts() public virtual returns (PhylaxCharts.Chart[] memory memCharts) {
+    function initCharts() internal virtual returns (PhylaxCharts.Chart[] memory memCharts) {
         memCharts = new PhylaxCharts.Chart[](PhylaxCharts.phylaxCharts.length);
         
         for (uint256 i; i < phylaxCharts.length; i++) {
@@ -100,7 +100,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         Visualisation visualization,
         DataPointType dataPointType,
         Label[] memory labels
-    ) public uniqueChartName(chartName) {
+    ) internal uniqueChartName(chartName) {
         string[] memory labelKeys = new string[](labels.length);
         string[] memory labelValues = new string[](labels.length);
 
@@ -136,7 +136,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory unitLabel,
         Visualisation visualization,
         DataPointType dataPointType
-    ) public uniqueChartName(chartName) {
+    ) internal uniqueChartName(chartName) {
         createChart(chartName, description, unitLabel, visualization, dataPointType, new Label[](0));
     }
 
@@ -156,7 +156,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         DataPointType dataPointType,
         Label[] memory labels,
         string[] memory chartNames
-    ) public {
+    ) internal {
         Label[] memory extendedLabels = new Label[](labels.length + 1);
         for (uint256 i = 0; i < labels.length; i++) {
             extendedLabels[i] = labels[i];
@@ -190,7 +190,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         Visualisation visualization,
         DataPointType dataPointType,
         string[] memory chartNames
-    ) public {
+    ) internal {
         createMultiChart(overlayKey, description, unitLabel, visualization, dataPointType, new Label[](0), chartNames);
     }
 
@@ -206,7 +206,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory unitLabel,
         DataPointType dataPointType,
         Label[] memory labels
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Line, dataPointType, labels);
     }
 
@@ -220,7 +220,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory description,
         string memory unitLabel,
         DataPointType dataPointType
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Line, dataPointType);
     }
 
@@ -236,7 +236,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory unitLabel,
         DataPointType dataPointType,
         Label[] memory labels
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Gauge, dataPointType, labels);
     }
 
@@ -250,7 +250,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory description,
         string memory unitLabel,
         DataPointType dataPointType
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Gauge, dataPointType);
     }
 
@@ -264,7 +264,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory description,
         string memory unitLabel,
         Label[] memory labels
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Table, DataPointType.String, labels);
     }
 
@@ -276,7 +276,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory chartName,
         string memory description,
         string memory unitLabel
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Table, DataPointType.String);
     }
 
@@ -292,7 +292,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory unitLabel,
         DataPointType dataPointType,
         Label[] memory labels
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Bar, dataPointType, labels);
     }
 
@@ -306,7 +306,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory description,
         string memory unitLabel,
         DataPointType dataPointType
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Bar, dataPointType);
     }
 
@@ -322,7 +322,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory unitLabel,
         DataPointType dataPointType,
         Label[] memory labels
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Heatmap, dataPointType, labels);
     }
 
@@ -336,7 +336,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory description,
         string memory unitLabel,
         DataPointType dataPointType
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.Heatmap, dataPointType);
     }
 
@@ -352,7 +352,7 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory unitLabel,
         DataPointType dataPointType,
         Label[] memory labels
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.LastValue, dataPointType, labels);
     }
 
@@ -366,67 +366,67 @@ abstract contract PhylaxCharts is PhylaxBase {
         string memory description,
         string memory unitLabel,
         DataPointType dataPointType
-    ) public {
+    ) internal {
         createChart(chartName, description, unitLabel, Visualisation.LastValue, dataPointType);
     }
 
-    function writeToChart(string memory chartName, uint64 value, Label[] memory labels) public {
+    function writeToChart(string memory chartName, uint64 value, Label[] memory labels) internal {
         require(chartByName[chartName].dataPointType == DataPointType.Uint, "Invalid dataPointType");
         writeDataPointUint(chartName, value, labels);
     }
 
-    function writeToChart(string memory chartName, uint64 value) public {
+    function writeToChart(string memory chartName, uint64 value) internal {
         require(chartByName[chartName].dataPointType == DataPointType.Uint, "Invalid dataPointType");
         writeToChart(chartName, value, new Label[](0));
     }
 
-    function writeToChart(string memory chartName, int64 value, Label[] memory labels) public {
+    function writeToChart(string memory chartName, int64 value, Label[] memory labels) internal {
         require(chartByName[chartName].dataPointType == DataPointType.Int, "Invalid dataPointType");
         writeDataPointInt(chartName, value, labels);
     }
 
-    function writeToChart(string memory chartName, int64 value) public {
+    function writeToChart(string memory chartName, int64 value) internal {
         require(chartByName[chartName].dataPointType == DataPointType.Int, "Invalid dataPointType");
         writeToChart(chartName, value, new Label[](0));
     }
 
-    function writeToChart(string memory chartName, address value, Label[] memory labels) public {
+    function writeToChart(string memory chartName, address value, Label[] memory labels) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, vm.toString(value), labels);
     }
 
-    function writeToChart(string memory chartName, address value) public {
+    function writeToChart(string memory chartName, address value) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, vm.toString(value), new Label[](0));
     }      
        
 
-    function writeToChart(string memory chartName, string memory value, Label[] memory labels) public {
+    function writeToChart(string memory chartName, string memory value, Label[] memory labels) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, value, labels);
     }
 
-    function writeToChart(string memory chartName, string memory value) public {
+    function writeToChart(string memory chartName, string memory value) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, value, new Label[](0));
     }
 
-    function writeToChart(string memory chartName, bytes32 value, Label[] memory labels) public {
+    function writeToChart(string memory chartName, bytes32 value, Label[] memory labels) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, vm.toString(value), labels);
     }
 
-    function writeToChart(string memory chartName, bytes32 value) public {
+    function writeToChart(string memory chartName, bytes32 value) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, vm.toString(value), new Label[](0));
     }
 
-    function writeToChart(string memory chartName, bytes memory value, Label[] memory labels) public {
+    function writeToChart(string memory chartName, bytes memory value, Label[] memory labels) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, vm.toString(value), labels);
     }
 
-    function writeToChart(string memory chartName, bytes memory value) public {
+    function writeToChart(string memory chartName, bytes memory value) internal {
         require(chartByName[chartName].dataPointType == DataPointType.String, "Invalid dataPointType");
         writeDataPointString(chartName, vm.toString(value), new Label[](0));
     }

--- a/src/PhylaxCharts.sol
+++ b/src/PhylaxCharts.sol
@@ -37,24 +37,6 @@ abstract contract PhylaxCharts is PhylaxBase {
         string[] labelValues;
     }
 
-    /// @notice The visualization enum for describing the type of chart you will create.
-    /// @dev This enum is used to create charts in the Phylax GUI and in the telemetry exports.
-    enum Visualisation {
-        Bar,
-        Line,
-        Heatmap,
-        Gauge,
-        Table,
-        LastValue
-    }
-
-    /// @notice The data point type enum for describing the type of data point you will create.
-    enum DataPointType {
-        Uint,
-        Int,
-        String
-    }
-
     /// @notice Modifier to enforce if a chart name is unique.
     modifier uniqueChartName(string memory chartName) {
         require(bytes(chartByName[chartName].chartName).length == 0, "Chart already exists");
@@ -96,8 +78,8 @@ abstract contract PhylaxCharts is PhylaxBase {
                 phylaxCharts[i].chartName,
                 phylaxCharts[i].description,
                 phylaxCharts[i].unitLabel,
-                uint8(phylaxCharts[i].visualization),
-                uint8(phylaxCharts[i].dataPointType),
+                phylaxCharts[i].visualization,
+                phylaxCharts[i].dataPointType,
                 labels
             );
         }

--- a/src/PhylaxNotification.sol
+++ b/src/PhylaxNotification.sol
@@ -21,7 +21,7 @@ abstract contract PhylaxNotification is PhylaxBase {
     }
 
     // helper functions
-    function info(string memory summary, string memory description) public pure returns (NotificationMessage memory) {
+    function info(string memory summary, string memory description) internal pure returns (NotificationMessage memory) {
         Label[] memory labels;
         return NotificationMessage({
             summary: summary,
@@ -32,7 +32,7 @@ abstract contract PhylaxNotification is PhylaxBase {
     }
 
     function info(string memory summary, string memory description, Label[] memory labels)
-        public
+        internal
         pure
         returns (NotificationMessage memory)
     {
@@ -45,7 +45,7 @@ abstract contract PhylaxNotification is PhylaxBase {
     }
 
     function warning(string memory summary, string memory description)
-        public
+        internal
         pure
         returns (NotificationMessage memory)
     {
@@ -59,7 +59,7 @@ abstract contract PhylaxNotification is PhylaxBase {
     }
 
     function warning(string memory summary, string memory description, Label[] memory labels)
-        public
+        internal
         pure
         returns (NotificationMessage memory)
     {
@@ -72,7 +72,7 @@ abstract contract PhylaxNotification is PhylaxBase {
     }
 
     function critical(string memory summary, string memory description)
-        public
+        internal
         pure
         returns (NotificationMessage memory)
     {
@@ -86,7 +86,7 @@ abstract contract PhylaxNotification is PhylaxBase {
     }
 
     function critical(string memory summary, string memory description, Label[] memory labels)
-        public
+        internal
         pure
         returns (NotificationMessage memory)
     {


### PR DESCRIPTION
These changes update the cheatcode interfaces associated with create fork logic, allowing people to only createFork on networks they've setup as triggers for their alert runtime.