### PR TITLE
add docs outline

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add code owners for docs.
+/docs/ @czepluch

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # forge
-docs/
 out/
 cache/
 # node

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# phylax-std docs
+
+The reference documentation for phylax-std lives in this folder.
+The content of this folder will be pulled into the [phylax-docs](https://github.com/phylaxsystems/phylax-docs) repo where it will be built and published.
+
+The README.md in the root folder should always be kept up to date, so that people are able to use phylax-std indepedently of the rest of the Phylax stack.
+
+## How to contribute to the phylax-std reference docs
+
+* Only add/update reference documentation to the `docs` folder in [this repository](https://github.com/phylaxsystems/phylax-std/tree/main/docs), not in the `phylax-docs` repo.
+* If you add a new file, please add it to the table of contents in the [phylax-docs](https://github.com/phylaxsystems/phylax-docs) repo.
+* Use MDX syntax for the reference docs.
+* Follow the structure of the existing files.

--- a/docs/references/action.mdx
+++ b/docs/references/action.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Action Reference'
+description: 'Reference of the Action smart contract'
+---
+
+## Intro
+Explain all functionality of Action.sol

--- a/docs/references/alert.mdx
+++ b/docs/references/alert.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Alert Reference'
+description: 'Reference of the Alert smart contract'
+---
+
+## Intro
+Explain all functionality of Alert.sol

--- a/docs/references/base.mdx
+++ b/docs/references/base.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Base Reference'
+description: 'Reference of the Base smart contract'
+---
+
+## Intro
+Explain all functionality of PhylaxBase.sol

--- a/docs/references/chart.mdx
+++ b/docs/references/chart.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Charts Reference'
+description: 'Reference of the Charts smart contract'
+---
+
+## Intro
+Explain all functionality of PhylaxCharts.sol

--- a/docs/references/introduction.mdx
+++ b/docs/references/introduction.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Introduction'
+description: 'Introduction to phylax-std'
+---
+
+## Intro
+General introduction and explanation of phylax-std.
+
+## Overview
+
+## Architecture
+
+## Concepts
+
+## Usage

--- a/docs/references/notification.mdx
+++ b/docs/references/notification.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Notification Reference'
+description: 'Reference of the Notification smart contract'
+---
+
+## Intro
+Explain all functionality of PhylaxNotification.sol

--- a/docs/references/phylax.mdx
+++ b/docs/references/phylax.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Phylax Reference'
+description: 'Reference of the Phylax smart contract'
+---
+
+## Intro
+Explain all functionality of Phylax.sol


### PR DESCRIPTION
Add outline of the reference docs needed for phylax-std

For some reason the .gitignore excluded `docs/`. Don't know what the reason was for that. If it's problematic that I removed it from there let me know and we can find a different solution.